### PR TITLE
Added Utils.BinarySearch, with native tag

### DIFF
--- a/src/BetterReplication/Lib/Utils.lua
+++ b/src/BetterReplication/Lib/Utils.lua
@@ -29,4 +29,29 @@ function Utils.PreRender(callback: (number) -> (), frequency: number)
 	end)
 end
 
+@native
+function Utils.BinarySearch(Array, Value)
+	local Low = 1
+	local High = #Array
+
+	while Low <= High do
+		local Middle = Low + math.floor((High - Low) / 2)
+		local MiddleValue = Array[Middle]
+
+		if Value < MiddleValue then
+			High = Middle - 1
+		elseif MiddleValue < Value then
+			Low = Middle + 1
+		else
+			while Middle >= 1 and not (Array[Middle] < Value or Value < Array[Middle]) do
+				Middle -= 1
+			end
+
+			return Middle + 1
+		end
+	end
+
+	return nil
+end
+
 return Utils

--- a/src/BetterReplication/PositionReplicator/UptodatePositions/init.lua
+++ b/src/BetterReplication/PositionReplicator/UptodatePositions/init.lua
@@ -82,7 +82,7 @@ ReplicationPackets.ReplicatePosition.listen(function(data, player)
 	
 	local outOfProximity = currentlyOutOfProximity[player]
 	for _, receiver in Players:GetPlayers() do
-		if receiver == player or table.find(outOfProximity, receiver) then
+		if receiver == player or Utils.BinarySearch(outOfProximity, receiver) then
 			continue
 		end
 
@@ -108,7 +108,7 @@ local function proximityClock(ht)
 			if subject == receiver then continue end
 			
 			local isInProximity = (receiverCframe.Position - cframe.Position).Magnitude <= Config.proximityThreshold
-			local outOfProximityIndex = table.find(
+			local outOfProximityIndex = Utils.BinarySearch(
 				currentlyOutOfProximity[receiver], 
 				subject
 			)


### PR DESCRIPTION
Binary search is a lot faster than table.find (more than ~7.4x faster), and when running something frequently (like at 20hz), the difference can be slightly noticeable.

To top it off, since the binary search ultimately uses math internally, using the @native tag makes it even faster (more than ~2.4x faster).

Below is an attached screenshot showcasing the performance difference on a benchmark ran with Boatbomber's Benchmarker plugin.
![image](https://github.com/user-attachments/assets/2e5cb98f-bc55-475b-babe-94ec45cc3f27)